### PR TITLE
Revert "Bump actions/labeler from 4.0.2 to 5.0.0"

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,6 +25,6 @@ jobs:
         allowed-endpoints: >
           api.github.com:443
 
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
+    - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts xf9c/CodeCoverageSummary#1

not ready for input format changes